### PR TITLE
Trim blank lines around verbatim text

### DIFF
--- a/src/octLexer.mll
+++ b/src/octLexer.mll
@@ -465,7 +465,7 @@ and verb = parse
     { raise (LexerError(curr_loc lexbuf, Nested_verbatim)) }
 | verb end
     { use_start_loc lexbuf;
-      Verb (get_raw_buffered_string ()) }
+      Verb (get_buffered_string ()) }
 | eof
     { raise (LexerError(get_start_loc (), Unterminated_verbatim)) }
 | newline
@@ -525,7 +525,7 @@ and pre_code = parse
     { raise (LexerError(curr_loc lexbuf, Nested_pre_code)) }
 | end_pre_code
     { use_start_loc lexbuf;
-      Pre_Code (get_raw_buffered_string ()) }
+      Pre_Code (get_buffered_string ()) }
 | eof
     { raise (LexerError(get_start_loc (), Unterminated_pre_code)) }
 | newline


### PR DESCRIPTION
Odoc currently produces output for code blocks that looks like this:

<br/>

> ![captura de pantalla 2017-10-11 a la s 15 34 44](https://user-images.githubusercontent.com/12073668/31465488-c1cf7c98-ae99-11e7-930c-00d7b2b537e6.png)

<br/>

Note the blank line at the top of the code block.

By comparison, ocamldoc produces the expected:

<br/>

> ![captura de pantalla 2017-10-11 a la s 15 34 11](https://user-images.githubusercontent.com/12073668/31465496-c8502b6c-ae99-11e7-859e-79cb97bc9407.png)

<br/>

It is common to have the starting delimiter of a raw code or verbatim text block on a separate line; likewise the ending delimiter:

```
{[
val parse_html : char stream   -> signal stream
val write_html : signal stream -> char stream
val parse_xml  : char stream   -> signal stream
val write_xml  : signal stream -> char stream
]}
```

The two extra newlines should not affect the interpretation or presentation of the code block. To get this, the commit in this PR passes the accumulated text through the existing `remove_opening_blanks` and `remove_closing_blanks`.

The result is

<br/>

> ![captura de pantalla 2017-10-11 a la s 15 33 59](https://user-images.githubusercontent.com/12073668/31465514-cf8bc6d4-ae99-11e7-91dc-a434a392b7fe.png)

<br/>

In addition to code blocks, this bug is also present for verbatim text blocks, but it is more difficult to observe because leading line breaks are ignored in `pre` content when parsing HTML ([reference](https://www.w3.org/TR/html5/syntax.html#parsing-main-inbody), see 'A start tag whose tag name is one of: "pre", "listing"'). For code blocks, the leading token generated by odoc in `pre` elements ends up being a nested `<code>` tag, not a line break, resulting in the visual bug.

Even though it's not visible, I fixed the bug in verbatim blocks as well, so that any future introduction of nested markup for verbatim blocks does not cause visual artifacts.